### PR TITLE
Remove version pins from requirements files

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,5 +5,5 @@ tqdm
 numpy
 pandas
 tenacity
-transformers==4.45.2
-torch==2.3.0
+transformers
+torch

--- a/requirements_ft.txt
+++ b/requirements_ft.txt
@@ -5,12 +5,11 @@ tqdm
 numpy
 pandas
 tenacity
-transformers==4.45.2
-torch==2.3.0
+transformers
+torch
 flash-attn==2.5.8
 deepspeed==0.13.5
-vllm==0.4.2
-xformers==0.0.26.post1
+vllm
 
 
 


### PR DESCRIPTION
Fix #1 

- Remove version constraints from transformers and torch in both requirements files
- Keep flash-attn==2.5.8 and deepspeed==0.13.5 pinned versions in requirements_ft
- Remove vllm version pin and completely remove xformers dependency

## Change Type
- Doc update


## Description
Update dependency management by removing strict version pins for most packages while maintaining specific versions for critical ML libraries. This allows for more flexible dependency resolution while keeping flash-attn and deepspeed at tested versions. Also removes xformers dependency entirely.

## Checklist
- Code self-tested
- Docs updated
- Tests added